### PR TITLE
Feature/investor acc details

### DIFF
--- a/lib/alpaca_client.ex
+++ b/lib/alpaca_client.ex
@@ -35,6 +35,15 @@ defmodule AlpacaInvestors.AlpacaClient do
     end
   end
 
+  def get_account_details(investor_id) do
+    client = client()
+
+    case Tesla.get(client, "/v1/accounts/#{investor_id}") do
+      {:ok, %Tesla.Env{status: 200, body: account}} -> {:ok, account}
+      {:ok, %Tesla.Env{body: error_body}} -> {:error, error_body}
+    end
+  end
+
   def create_funded_user() do
     client = client()
 

--- a/lib/alpaca_investors.ex
+++ b/lib/alpaca_investors.ex
@@ -17,12 +17,17 @@ defmodule AlpacaInvestors do
     Agent.start_link(fn -> investor_ids end, name: __MODULE__)
   end
 
-  def fetch_investor do
+  def fetch_investor(opts) do
+    cleanup = Keyword.get(opts, :cleanup, true)
+
     Agent.get_and_update(__MODULE__, fn investor_ids ->
       [investor_id | investor_ids] = investor_ids
 
       Task.start_link(fn -> AlpacaClient.create_funded_user() end)
-      Task.start_link(fn -> AlpacaClient.exhaust_investor(investor_id) end)
+
+      if cleanup do
+        Task.start_link(fn -> AlpacaClient.exhaust_investor(investor_id) end)
+      end
 
       {investor_id, investor_ids}
     end)


### PR DESCRIPTION
- [x] Add call to fetch investor account details (email)
- [x] Allow cleanup to be skipped when fetching an investor - Lets the investor web use an investor and clean it up after integration test succeeds or fails